### PR TITLE
Fix quarter/season calculation to use US Eastern time

### DIFF
--- a/src/scripts/genius.js
+++ b/src/scripts/genius.js
@@ -47,8 +47,9 @@ async function fetchAllAlphas(forceRefresh = false, isSelf = false) { // Added i
     }
 
 
-    const currentDate = new Date();
-    const year = currentDate.getUTCFullYear();
+    // Use Eastern Time to determine current quarter (not browser local time)
+    const currentDate = getEasternTimeDate();
+    const year = currentDate.getFullYear();
     const quarter = Math.floor((currentDate.getMonth() + 3) / 3);
     const quarters = [
         { start: `${year}-01-01T05:00:00.000Z`, end: `${year}-04-01T04:00:00.000Z` },  // 第一季度

--- a/src/scripts/utils.js
+++ b/src/scripts/utils.js
@@ -196,6 +196,25 @@ function formatSavedTimestamp(dateString) {
     return [easternTime, beijingTime];
 }
 
+// Get current time as a Date object in Eastern timezone
+// This is used for date arithmetic and comparisons in Eastern time
+function getEasternTimeDate() {
+    const now = new Date();
+    const easternStr = now.toLocaleString("en-US", {
+        timeZone: "America/New_York"
+    });
+    return new Date(easternStr);
+}
+
+// Convert any date to Eastern timezone for comparison
+function toEasternTime(date) {
+    const d = new Date(date);
+    const easternStr = d.toLocaleString("en-US", {
+        timeZone: "America/New_York"
+    });
+    return new Date(easternStr);
+}
+
 // 定义一个变量来存储已提交的 Alpha 列表和上次更新时间
 let submittedAlphasCache = {
     data: [],


### PR DESCRIPTION
Add timezone helper functions and update season detection to use Eastern time instead of browser local time. This prevents incorrect season calculation when browser timezone differs from ET.

Changes:
- Add getEasternTimeDate() and toEasternTime() helper functions
- Update fetchAllAlphas to use Eastern time for quarter calculation

🤖 Generated with [Claude Code](https://claude.com/claude-code)