### PR TITLE
fix: 修复社区数据导出超过 Chrome 扩展 64MiB 消息限制的问题

### DIFF
--- a/src/background/services/sidebarMessageRouter.js
+++ b/src/background/services/sidebarMessageRouter.js
@@ -32,12 +32,6 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     if (msg.type === 'WQP_SETTINGS_SAVE') {
         return respond(sendResponse, saveSettings(msg.settings));
     }
-    if (msg.type === 'WQP_COMMUNITY_STATE_GET') {
-        return respond(sendResponse, getLocalValue('WQP_CommunityState'));
-    }
-    if (msg.type === 'WQP_COMMUNITY_STATE_SET') {
-        return respond(sendResponse, setLocalValue('WQP_CommunityState', msg.state).then(() => msg.state));
-    }
     if (msg.type === 'WQP_SESSION_GET') {
         return respond(sendResponse, getSessionKeeperState());
     }

--- a/src/ui/popup/popup.js
+++ b/src/ui/popup/popup.js
@@ -136,20 +136,8 @@ settingsForm.addEventListener('submit', saveSettings);
 document.addEventListener('DOMContentLoaded', loadSettings);
 
 // ========== 社区数据 导出/导入 ==========
-function downloadText(filename, text) {
-    const blob = new Blob([text], { type: 'application/json;charset=utf-8' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = filename;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
-}
-
 function downloadBytes(filename, bytes, mime = 'application/octet-stream') {
-    const blob = new Blob([bytes], { type: mime });
+    const blob = bytes instanceof Blob ? bytes : new Blob([bytes], { type: mime });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
@@ -166,6 +154,87 @@ function formatNow() {
     return `${d.getFullYear()}${pad(d.getMonth() + 1)}${pad(d.getDate())}_${pad(d.getHours())}${pad(d.getMinutes())}${pad(d.getSeconds())}`;
 }
 
+const COMPRESSED_JSON_FORMAT_HEADER = 'WQCS_JSON_V1\n';
+const JSON_CHUNK_MAX_CHARS = 256 * 1024;
+const JSON_INDENT = '  ';
+
+function createJsonChunkWriter(onChunk) {
+    let buffer = '';
+    const flush = () => { if (!buffer) return; onChunk(buffer); buffer = ''; };
+    const push = (text) => {
+        if (!text) return;
+        let offset = 0;
+        while (offset < text.length) {
+            const available = JSON_CHUNK_MAX_CHARS - buffer.length;
+            buffer += text.slice(offset, offset + available);
+            offset += available;
+            if (buffer.length >= JSON_CHUNK_MAX_CHARS) flush();
+        }
+    };
+    return { push, flush };
+}
+
+function pushJsonValue(push, value, depth = 0) {
+    if (value === null || typeof value !== 'object') { push(JSON.stringify(value) ?? 'null'); return; }
+    if (Array.isArray(value)) {
+        if (!value.length) { push('[]'); return; }
+        push('[\n');
+        value.forEach((item, index) => {
+            push(JSON_INDENT.repeat(depth + 1));
+            pushJsonValue(push, item === undefined ? null : item, depth + 1);
+            push(index === value.length - 1 ? '\n' : ',\n');
+        });
+        push(`${JSON_INDENT.repeat(depth)}]`);
+        return;
+    }
+    const keys = Object.keys(value).filter((k) => value[k] !== undefined);
+    if (!keys.length) { push('{}'); return; }
+    push('{\n');
+    keys.forEach((key, index) => {
+        push(JSON_INDENT.repeat(depth + 1));
+        push(`${JSON.stringify(key)}: `);
+        pushJsonValue(push, value[key], depth + 1);
+        push(index === keys.length - 1 ? '\n' : ',\n');
+    });
+    push(`${JSON_INDENT.repeat(depth)}}`);
+}
+
+function createCommunityStateJsonBlob(state) {
+    const parts = [];
+    const writer = createJsonChunkWriter((chunk) => parts.push(chunk));
+    pushJsonValue(writer.push, state);
+    writer.push('\n');
+    writer.flush();
+    return new Blob(parts, { type: 'application/json;charset=utf-8' });
+}
+
+function createCompressedCommunityStateBlob(state) {
+    const chunks = [];
+    const encoder = new TextEncoder();
+    const deflator = new pako.Deflate();
+    const writer = createJsonChunkWriter((chunk) => {
+        deflator.push(encoder.encode(chunk), false);
+        if (deflator.err) throw new Error(deflator.msg || '压缩社区数据失败。');
+    });
+    deflator.onData = (chunk) => chunks.push(chunk);
+    writer.push(COMPRESSED_JSON_FORMAT_HEADER);
+    pushJsonValue(writer.push, state);
+    writer.push('\n');
+    writer.flush();
+    deflator.push(new Uint8Array(0), true);
+    if (deflator.err) throw new Error(deflator.msg || '压缩社区数据失败。');
+    return new Blob(chunks, { type: 'application/octet-stream' });
+}
+
+function decodeCompressedCommunityState(data) {
+    const inflated = pako.inflate(new Uint8Array(data));
+    const prefix = new TextEncoder().encode(COMPRESSED_JSON_FORMAT_HEADER);
+    if (inflated.length >= prefix.length && prefix.every((b, i) => inflated[i] === b)) {
+        return JSON.parse(new TextDecoder().decode(inflated.subarray(prefix.length)));
+    }
+    return msgpack.decode(inflated);
+}
+
 function handleExportCommunity() {
     statusText.textContent = '导出中...';
     chrome.storage.local.get('WQP_CommunityState', ({ WQP_CommunityState }) => {
@@ -174,8 +243,7 @@ function handleExportCommunity() {
                 showStatusMessage('没有可导出的社区数据。', false);
                 return;
             }
-            const json = JSON.stringify(WQP_CommunityState, null, 2);
-            downloadText(`WQP_CommunityState_${formatNow()}.json`, json);
+            downloadBytes(`WQP_CommunityState_${formatNow()}.json`, createCommunityStateJsonBlob(WQP_CommunityState));
             showStatusMessage('导出完成。', true);
         } catch (e) {
             console.error(e);
@@ -192,10 +260,7 @@ function handleExportCommunityCompressed() {
                 showStatusMessage('没有可导出的社区数据。', false);
                 return;
             }
-            // 使用 msgpack 编码 + pako 压缩
-            const packed = msgpack.encode(WQP_CommunityState);
-            const deflated = pako.deflate(packed);
-            downloadBytes(`WQP_CommunityState_${formatNow()}.wqcs`, deflated, 'application/octet-stream');
+            downloadBytes(`WQP_CommunityState_${formatNow()}.wqcs`, createCompressedCommunityStateBlob(WQP_CommunityState));
             showStatusMessage('压缩导出完成。', true);
         } catch (e) {
             console.error(e);
@@ -218,9 +283,7 @@ function handleImportFileChange(evt) {
     if (isCompressed) {
         reader.onload = () => {
             try {
-                const arr = new Uint8Array(reader.result);
-                const inflated = pako.inflate(arr);
-                const obj = msgpack.decode(inflated);
+                const obj = decodeCompressedCommunityState(reader.result);
                 chrome.storage.local.set({ WQP_CommunityState: obj }, () => {
                     if (chrome.runtime.lastError) {
                         showStatusMessage('写入存储失败。', false);

--- a/src/ui/sidebar/modules/communityPanel.js
+++ b/src/ui/sidebar/modules/communityPanel.js
@@ -1,5 +1,5 @@
-﻿import { createCommunityPort, sendMessage } from './runtimeClient.js';
-import { downloadBytes, downloadText, formatNow, setStatus } from './ui.js';
+﻿import { createCommunityPort } from './runtimeClient.js';
+import { downloadBytes, formatNow, setStatus } from './ui.js';
 
 let communityPort = null;
 let running = false;
@@ -9,6 +9,11 @@ const DEFAULT_PROGRESS_LABELS = {
     overall: '总进度',
     detail: '当前阶段',
 };
+
+const COMMUNITY_STATE_KEY = 'WQP_CommunityState';
+const COMPRESSED_JSON_FORMAT_HEADER = 'WQCS_JSON_V1\n';
+const JSON_CHUNK_MAX_CHARS = 256 * 1024;
+const JSON_INDENT = '  ';
 
 const progressNodes = new Map();
 
@@ -310,15 +315,153 @@ function runCommunityAction(action, payload) {
     ensurePort().run(action, payload);
 }
 
+function getCommunityStateFromStorage() {
+    return new Promise((resolve, reject) => {
+        chrome.storage.local.get(COMMUNITY_STATE_KEY, (items) => {
+            if (chrome.runtime.lastError) {
+                reject(new Error(chrome.runtime.lastError.message));
+                return;
+            }
+            resolve(items?.[COMMUNITY_STATE_KEY]);
+        });
+    });
+}
+
+function setCommunityStateToStorage(state) {
+    return new Promise((resolve, reject) => {
+        chrome.storage.local.set({ [COMMUNITY_STATE_KEY]: state }, () => {
+            if (chrome.runtime.lastError) {
+                reject(new Error(chrome.runtime.lastError.message));
+                return;
+            }
+            resolve();
+        });
+    });
+}
+
+function createJsonChunkWriter(onChunk) {
+    let buffer = '';
+    const flush = () => {
+        if (!buffer) return;
+        onChunk(buffer);
+        buffer = '';
+    };
+    const push = (text) => {
+        if (!text) return;
+        let offset = 0;
+        while (offset < text.length) {
+            const available = JSON_CHUNK_MAX_CHARS - buffer.length;
+            buffer += text.slice(offset, offset + available);
+            offset += available;
+            if (buffer.length >= JSON_CHUNK_MAX_CHARS) flush();
+        }
+    };
+    return { push, flush };
+}
+
+function pushIndent(push, depth) {
+    push(JSON_INDENT.repeat(depth));
+}
+
+function pushJsonArray(push, value, depth) {
+    if (!value.length) {
+        push('[]');
+        return;
+    }
+    push('[\n');
+    value.forEach((item, index) => {
+        pushIndent(push, depth + 1);
+        pushJsonValue(push, item === undefined ? null : item, depth + 1);
+        push(index === value.length - 1 ? '\n' : ',\n');
+    });
+    pushIndent(push, depth);
+    push(']');
+}
+
+function pushJsonObject(push, value, depth) {
+    const keys = Object.keys(value).filter((key) => value[key] !== undefined);
+    if (!keys.length) {
+        push('{}');
+        return;
+    }
+    push('{\n');
+    keys.forEach((key, index) => {
+        pushIndent(push, depth + 1);
+        push(`${JSON.stringify(key)}: `);
+        pushJsonValue(push, value[key], depth + 1);
+        push(index === keys.length - 1 ? '\n' : ',\n');
+    });
+    pushIndent(push, depth);
+    push('}');
+}
+
+function pushJsonValue(push, value, depth = 0) {
+    if (value === null || typeof value !== 'object') {
+        push(JSON.stringify(value) ?? 'null');
+        return;
+    }
+
+    if (Array.isArray(value)) {
+        pushJsonArray(push, value, depth);
+        return;
+    }
+
+    pushJsonObject(push, value, depth);
+}
+
+function createCommunityStateJsonBlob(state) {
+    const parts = [];
+    const writer = createJsonChunkWriter((chunk) => parts.push(chunk));
+    pushJsonValue(writer.push, state);
+    writer.push('\n');
+    writer.flush();
+    return new Blob(parts, { type: 'application/json;charset=utf-8' });
+}
+
+function createCompressedCommunityStateBlob(state) {
+    const chunks = [];
+    const encoder = new TextEncoder();
+    const deflator = new pako.Deflate();
+    const writer = createJsonChunkWriter((chunk) => {
+        deflator.push(encoder.encode(chunk), false);
+        if (deflator.err) throw new Error(deflator.msg || '压缩社区数据失败。');
+    });
+
+    deflator.onData = (chunk) => chunks.push(chunk);
+    writer.push(COMPRESSED_JSON_FORMAT_HEADER);
+    pushJsonValue(writer.push, state);
+    writer.push('\n');
+    writer.flush();
+    deflator.push(new Uint8Array(0), true);
+    if (deflator.err) throw new Error(deflator.msg || '压缩社区数据失败。');
+    return new Blob(chunks, { type: 'application/octet-stream' });
+}
+
+function byteArrayStartsWith(bytes, text) {
+    const prefix = new TextEncoder().encode(text);
+    if (bytes.length < prefix.length) return false;
+    for (let index = 0; index < prefix.length; index += 1) {
+        if (bytes[index] !== prefix[index]) return false;
+    }
+    return true;
+}
+
+function decodeCompressedCommunityState(data) {
+    const inflated = pako.inflate(new Uint8Array(data));
+    if (byteArrayStartsWith(inflated, COMPRESSED_JSON_FORMAT_HEADER)) {
+        const jsonBytes = inflated.subarray(COMPRESSED_JSON_FORMAT_HEADER.length);
+        return JSON.parse(new TextDecoder().decode(jsonBytes));
+    }
+    return msgpack.decode(inflated);
+}
+
 async function exportCommunity(compressed) {
-    const state = await sendMessage('WQP_COMMUNITY_STATE_GET');
+    const state = await getCommunityStateFromStorage();
     if (!state) throw new Error('没有可导出的社区数据。');
     if (compressed) {
-        const packed = msgpack.encode(state);
-        const deflated = pako.deflate(packed);
-        downloadBytes(`WQP_CommunityState_${formatNow()}.wqcs`, deflated);
+        downloadBytes(`WQP_CommunityState_${formatNow()}.wqcs`, createCompressedCommunityStateBlob(state));
     } else {
-        downloadText(`WQP_CommunityState_${formatNow()}.json`, JSON.stringify(state, null, 2));
+        downloadBytes(`WQP_CommunityState_${formatNow()}.json`, createCommunityStateJsonBlob(state), 'application/json;charset=utf-8');
     }
 }
 
@@ -334,12 +477,11 @@ async function importCommunity(file) {
 
     let state;
     if (compressed) {
-        const inflated = pako.inflate(new Uint8Array(data));
-        state = msgpack.decode(inflated);
+        state = decodeCompressedCommunityState(data);
     } else {
         state = JSON.parse(data);
     }
-    await sendMessage('WQP_COMMUNITY_STATE_SET', { state });
+    await setCommunityStateToStorage(state);
 }
 
 function getActiveTabUrl() {
@@ -423,20 +565,26 @@ export function initCommunityPanel() {
     });
 
     exportCommunityBtn.addEventListener('click', async () => {
+        exportCommunityBtn.classList.add('loading');
         try {
             await exportCommunity(false);
             setStatus('社区数据 JSON 导出完成。', 'success');
         } catch (error) {
             setStatus(`导出失败：${error.message}`, 'error');
+        } finally {
+            exportCommunityBtn.classList.remove('loading');
         }
     });
 
     exportCommunityCompressedBtn.addEventListener('click', async () => {
+        exportCommunityCompressedBtn.classList.add('loading');
         try {
             await exportCommunity(true);
             setStatus('社区数据压缩导出完成。', 'success');
         } catch (error) {
             setStatus(`导出失败：${error.message}`, 'error');
+        } finally {
+            exportCommunityCompressedBtn.classList.remove('loading');
         }
     });
 

--- a/src/ui/sidebar/sidebar.css
+++ b/src/ui/sidebar/sidebar.css
@@ -210,6 +210,27 @@ button.danger:hover {
     background: var(--danger-dark);
 }
 
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
+button.loading {
+    pointer-events: none;
+}
+
+button.loading::before {
+    content: '';
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    margin-right: 6px;
+    border: 2px solid currentColor;
+    border-top-color: transparent;
+    border-radius: 50%;
+    vertical-align: middle;
+    animation: spin 0.6s linear infinite;
+}
+
 .info-box {
     min-height: 36px;
     margin-top: 8px;


### PR DESCRIPTION
## 问题

全量抓取后点击「导出 JSON」或「导出压缩」时报错：

```
Message exceeded maximum allowed size of 64MiB.
```

根因：`exportCommunity()` 通过 `chrome.runtime.sendMessage` 向 background 请求完整 `WQP_CommunityState`，当数据体积超过 Chrome 扩展 runtime message 64MiB 上限时传输失败。压缩导出同样受影响，因为压缩发生在 side panel 收到完整 state 之后。

## 修复内容

**绕过 runtime message 限制**
- `communityPanel.js` / `popup.js`：导出时直接调用 `chrome.storage.local.get()` 读取 state，不再经过 background message 传输。
- `sidebarMessageRouter.js`：删除不再使用的 `WQP_COMMUNITY_STATE_GET` / `WQP_COMMUNITY_STATE_SET` 两个 handler。

**防止大数据序列化时的内存峰值**
- 新增分块 JSON writer（`createJsonChunkWriter` + `pushJsonValue`），将大对象序列化直接写入 `Blob` 的 parts 数组，全程不产生完整的超大字符串。

**压缩导出改用新格式**
- 压缩导出改为 streaming deflate（逐块喂给 `pako.Deflate`），同样避免在内存中展开完整字符串。
- 新 `.wqcs` 文件头为 `WQCS_JSON_V1\n`，内容为 deflate 压缩的 JSON。
- 导入时自动检测格式头，向后兼容旧 msgpack 格式。

**导出按钮 loading 状态**
- 导出期间按钮显示旋转 spinner，操作完成后自动消失，防止重复点击。

## 验证点

- 构造接近或超过 64MiB 的 `WQP_CommunityState`，JSON 导出和压缩导出均不再触发 runtime message size 错误。
- 导入导出 round-trip 后数据结构保持一致。
- 旧格式 `.wqcs`（msgpack + deflate）仍可正常导入。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)