### PR TITLE
Update genius.js: Python alpha不参与计算op相关的六维，但当前运算符分析并未排除Python alpha

### DIFF
--- a/src/content/platform/genius/genius.js
+++ b/src/content/platform/genius/genius.js
@@ -99,7 +99,7 @@ async function fetchAllAlphas(forceRefresh = false, isSelf = false) { // Added i
     const dateRange = `dateSubmitted%3E${start}&dateSubmitted%3C${end}`;
 
     const limit = 30; // Data limit per page
-    const formatUrl = `https://api.worldquantbrain.com/users/self/alphas?limit={limit}&offset={offset}&status!=UNSUBMITTED%1FIS-FAIL&${dateRange}&order=-dateCreated&hidden=false`
+    const formatUrl = `https://api.worldquantbrain.com/users/self/alphas?limit={limit}&offset={offset}&status!=UNSUBMITTED%1FIS-FAIL&settings.language=FASTEXPR&${dateRange}&order=-dateCreated&hidden=false`
     let data = await getDataFromUrlWithOffsetParallel(formatUrl, limit, 'WQPOPSFetchButton')
 
     // Save to cache


### PR DESCRIPTION
Python alpha不参与计算op相关的两个六维，但当前运算符分析并未排除Python alpha

修改了src/content/platform/genius/genius.js line 102

增加了settings.language=FASTEXPR ，从而仅针对FASTEXPR alpha进行运算符分析